### PR TITLE
Fix exception when PM sensor is not configured

### DIFF
--- a/custom_components/iaquk/__init__.py
+++ b/custom_components/iaquk/__init__.py
@@ -319,6 +319,9 @@ class Iaquk:
         to Indoor Air Quality UK: http://www.iaquk.org.uk/ """
         entity_ids = self._sources.get(CONF_PM)
 
+        if entity_ids is None:
+            return None
+
         values = []
         for eid in entity_ids:
             val = self._get_number_state(eid)


### PR DESCRIPTION
Fixed exception when PM sensor is not present in configuration.
This task is mentioned in bug #2