### PR TITLE
Support µg/m³ unit for PM

### DIFF
--- a/custom_components/iaquk/const.py
+++ b/custom_components/iaquk/const.py
@@ -36,4 +36,7 @@ UNIT_PPB = {
     'ppb': 1,
     'ppm': 1000,
 }
-UNIT_MGM3 = 'µg/m3'
+UNIT_MGM3 = {
+    'µg/m3': 1,
+    'µg/m³': 1
+}


### PR DESCRIPTION
There are two similar units used in HA: https://github.com/home-assistant/home-assistant/search?q=%C2%B5g%2F&unscoped_q=%C2%B5g%2F