### PR TITLE
bugfix state class measurement

### DIFF
--- a/custom_components/iaquk/sensor.py
+++ b/custom_components/iaquk/sensor.py
@@ -71,7 +71,10 @@ class IaqukSensor(SensorEntity):
 
         self._attr_unique_id = f"{controller.unique_id}_{sensor_type}"
         self._attr_name = f"{controller.name} {SENSORS[sensor_type]}"
-        self._attr_state_class = STATE_CLASS_MEASUREMENT
+        
+        if sensor_type == SENSOR_INDEX:
+            self._attr_state_class = STATE_CLASS_MEASUREMENT
+
         self._attr_device_class = (
             f"{DOMAIN}__level" if sensor_type == SENSOR_LEVEL else None
         )


### PR DESCRIPTION
Removed state class measurement from the level sensor as it seems HA does not display history correct with this attribute on text sensors