### PR TITLE
Fix state_class attribute for entities

### DIFF
--- a/custom_components/iaquk/sensor.py
+++ b/custom_components/iaquk/sensor.py
@@ -72,7 +72,9 @@ class IaqukSensor(SensorEntity):
 
         self._attr_unique_id = f"{controller.unique_id}_{sensor_type}"
         self._attr_name = f"{controller.name} {SENSORS[sensor_type]}"
-        self._attr_state_class = STATE_CLASS_MEASUREMENT
+        self._attr_state_class = (
+            STATE_CLASS_MEASUREMENT if sensor_type == SENSOR_INDEX else None
+        )
         self._attr_device_class = (
             f"{DOMAIN}__level" if sensor_type == SENSOR_LEVEL else None
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -36,6 +36,7 @@ async def test_entity_initialization(hass: HomeAssistant):
     assert entity.should_poll is True
     assert entity.available is True
     assert entity.state is None
+    assert entity.state_class == "measurement"
     assert entity.icon == ICON_DEFAULT
     assert entity.unit_of_measurement == "IAQI"
     assert entity.extra_state_attributes == expected_attributes
@@ -48,6 +49,7 @@ async def test_entity_initialization(hass: HomeAssistant):
     assert entity.should_poll is True
     assert entity.available is True
     assert entity.state is None
+    assert entity.state_class is None
     assert entity.icon == ICON_FAIR
     assert entity.unit_of_measurement is None
     assert entity.extra_state_attributes == expected_attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Since v2023.5 the IAQ-Level entities fail with

> Sensor sensor.iaquk_home_indoor_air_quality_level has device class None, state class measurement and unit None thus indicating it has a numeric value; however, it has the non-numeric value: Good (<class 'str'>); Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.

This PR fixes the conflicts in the attribute definitions by only setting the `state_class` attribute for the IAQ-Index entities.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #109, #104, #117, #118

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Black (`black --fast custom_components`)

<!--
  Thank you for contributing <3
-->